### PR TITLE
Add a preset for enabling Red Hat versioning for container images

### DIFF
--- a/redhat-image-versions.json
+++ b/redhat-image-versions.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "registry.access.redhat.com/rhel",
+                "registry.access.redhat.com/rhel-atomic",
+                "registry.access.redhat.com/rhel-init",
+                "registry.access.redhat.com/rhel-minimal",
+                "registry.access.redhat.com/rhceph/**",
+                "registry.access.redhat.com/rhgs3/**",
+                "registry.access.redhat.com/rhel7**",
+                "registry.access.redhat.com/rhel8/**",
+                "registry.access.redhat.com/rhel9/**",
+                "registry.access.redhat.com/rhscl/**",
+                "registry.access.redhat.com/ubi*{,/}**",
+                "redhat/**",
+                "registry.redhat.io/*",
+                "registry.stage.redhat.io/*"
+            ],
+            "versioning": "redhat"
+        }
+    ]
+}


### PR DESCRIPTION
After some considerations, I am making this a preset (will update the docs as well), for these reasons:

- Renovate uses the `docker` versioning by default for docker images, which doesn't cover Red Hat images (`semver` probably would, but there's already `redhat` versioning)
- The registry.redhat.io requires authentication and is thus locked into Red Hat ecosystem so in my opinion it doesn't make sense to push into upstream if it doesn't work for everyone