### PR TITLE
feat: Disable Major and Minor Version Updates

### DIFF
--- a/disable-minor-updates.json
+++ b/disable-minor-updates.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [":disableMajorUpdates"],
+    "minor": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
Add presets to disable major and/or minor version updates from Renovate. This is useful in many contexts, especially for projects that promise certian levels of stability and reliability.

Fixes #5 

See also: https://issues.redhat.com/browse/CWFHEALTH-4558