### PR TITLE
Update CVE automerge presets for RPM updates

### DIFF
--- a/cve-automerge-all.json
+++ b/cve-automerge-all.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "rpmVulnerabilityAutomerge": "ALL",
     "packageRules": [
         {
         "matchJsonata": [

--- a/cve-automerge-critical.json
+++ b/cve-automerge-critical.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "rpmVulnerabilityAutomerge": "CRITICAL",
     "packageRules": [
         {
         "matchJsonata": [

--- a/cve-automerge-high.json
+++ b/cve-automerge-high.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "rpmVulnerabilityAutomerge": "HIGH",
     "packageRules": [
         {
         "matchJsonata": [

--- a/cve-automerge-moderate.json
+++ b/cve-automerge-moderate.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "rpmVulnerabilityAutomerge": "MEDIUM",
     "packageRules": [
         {
         "matchJsonata": [


### PR DESCRIPTION
The current presets do not apply to RPM updates. This change adds the MintMaker-specific setting 'rpmVulnerabilityAutomerge' to fix this.