### PR TITLE
Add preset for refresh-rpm-lockfiles

### DIFF
--- a/refresh-rpm-lockfiles.json
+++ b/refresh-rpm-lockfiles.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "refresh-rpm-lockfiles -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+        ],
+        "fileFilters": [
+          "**/rpms.lock.yaml"
+        ],
+        "executionMode": "branch",
+        "dataFileTemplate": "[{{#each upgrades}}{\"packageFile\": \"{{{packageFile}}}\"}{{#unless @last}},{{\/unless}}{{\/each}}]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This is configuration for https://github.com/konflux-ci/refresh-rpm-lockfiles, so that this option is not available automatically for all repos, but an opt-in for users who need this functionality.